### PR TITLE
Add basic ordering flow with cart and checkout

### DIFF
--- a/src/app/checkout/page.tsx
+++ b/src/app/checkout/page.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import React from 'react';
+import {useCart} from '@/app/lib/cart';
+import {cartSubtotalCents, taxCents, totalCents} from '@/app/lib/pricing';
+
+function Money({cents}: {cents: number}) {
+  return <span>${(cents/100).toFixed(2)}</span>;
+}
+
+export default function CheckoutPage() {
+  const {items, tipCents, setTipCents, clear} = useCart();
+  const taxRate = Number(process.env.NEXT_PUBLIC_TAX_RATE || 0);
+  const subtotal = cartSubtotalCents(items);
+  const tax = taxCents(subtotal, taxRate);
+  const total = totalCents(subtotal, tax, tipCents);
+
+  function placeOrder() {
+    alert('Order placed!');
+    clear();
+  }
+
+  return (
+    <main className="mx-auto max-w-2xl space-y-6">
+      <section className="rounded-2xl border bg-white p-4 shadow-sm">
+        <h2 className="text-lg font-semibold mb-3">Checkout</h2>
+        <div className="space-y-2">
+          {items.map((it, i) => (
+            <div key={i} className="flex justify-between">
+              <span>{it.name} x{it.quantity}</span>
+              <Money cents={(it.basePriceCents + it.modifiers.reduce((s,m)=>s+m.priceCents,0)) * it.quantity} />
+            </div>
+          ))}
+        </div>
+        <div className="mt-4 space-y-1 text-sm">
+          <div className="flex justify-between"><span>Subtotal</span><Money cents={subtotal} /></div>
+          <div className="flex justify-between"><span>Tax</span><Money cents={tax} /></div>
+          <div className="flex justify-between"><span>Tip</span>
+            <input
+              type="number"
+              className="ml-2 w-20 rounded border p-1"
+              value={(tipCents/100).toFixed(2)}
+              onChange={e=>setTipCents(Math.max(0, Math.round(Number(e.target.value)*100)))}
+            />
+          </div>
+          <div className="flex justify-between font-semibold"><span>Total</span><Money cents={total} /></div>
+        </div>
+        <button onClick={placeOrder} className="mt-4 w-full rounded-xl bg-black py-2 text-white">Place Order</button>
+      </section>
+    </main>
+  );
+}

--- a/src/app/checkout/page.tsx
+++ b/src/app/checkout/page.tsx
@@ -21,7 +21,7 @@ export default function CheckoutPage() {
   }
 
   return (
-    <main className="mx-auto max-w-2xl space-y-6">
+    <main className="mx-auto max-w-2xl space-y-6 mt-32">
       <section className="rounded-2xl border bg-white p-4 shadow-sm">
         <h2 className="text-lg font-semibold mb-3">Checkout</h2>
         <div className="space-y-2">

--- a/src/app/components/Cookie/Cookie.tsx
+++ b/src/app/components/Cookie/Cookie.tsx
@@ -1,0 +1,3 @@
+// Dominos' Menu - Order Pizza, Pasta, Wings & More Online!
+// We value your privacy.​
+// We and third parties we work with use cookies and other technologies to collect and disclose information about you for the purposes described in our Privacy Policy. Click “Reject All” to disable non-essential technologies and opt-out of sales, shares, and targeted advertising on this site. You can also use a recognized preference signal like Global Privacy Control. These choices apply only to this browser and reset if you clear cookies. To opt-out for our mobile app, configure “Do Not Sell” within the app. To opt-out for information we have about you in our systems (like your email address), submit a separate request through this link.

--- a/src/app/components/Header/Header.module.css
+++ b/src/app/components/Header/Header.module.css
@@ -17,6 +17,12 @@
     }
 }
 
+.headerNoScroll {
+    .inner {
+        color: #3F3126;
+    }
+}
+
 .link {
     font-size: 14px;
     font-weight: 700;

--- a/src/app/components/Header/Header.tsx
+++ b/src/app/components/Header/Header.tsx
@@ -3,7 +3,7 @@ import {useState, useEffect, useRef} from 'react';
 import styles from './Header.module.css';
 
 const navItems = [
-    {label: 'ORDER NOW', href: 'https://goodchickenusa.com/', emphasize: true},
+    {label: 'ORDER NOW', href: '/order', emphasize: true},
     {label: 'LOCATIONS', href: '#FindUs'},
     {label: 'MENU', href: '#Menu'},
     {label: 'CATERING', href: '#Contact'},
@@ -15,6 +15,7 @@ export default function Header() {
     const [open, setOpen] = useState(false);
     const menuRef = useRef<HTMLDivElement | null>(null);
     const [scrolled, setScrolled] = useState(false);
+    const [noScroll, setNoScroll] = useState(false);
 
     const mid = Math.ceil(navItems.length / 2);
     const leftItems = navItems.slice(0, mid);
@@ -48,10 +49,32 @@ export default function Header() {
         return () => window.removeEventListener("scroll", onScroll);
     }, []);
 
+    useEffect(() => {
+        const update = () => {
+            const root = document.documentElement;
+            const body = document.body;
+            const scrollH = Math.max(root.scrollHeight, body.scrollHeight);
+            const clientH = root.clientHeight;
+            // tiny fudge factor for sub-pixel rounding
+            setNoScroll(scrollH <= clientH + 1);
+        };
+
+        update();                 // on mount
+        const ro = new ResizeObserver(update);
+        ro.observe(document.documentElement);
+        window.addEventListener("resize", update);
+
+        return () => {
+            ro.disconnect();
+            window.removeEventListener("resize", update);
+        };
+    }, []);
+
+    const darkAssets = scrolled || noScroll;
 
     return (
         <header
-            className={`${styles.header} ${scrolled ? styles.headerScrolled : ""}`}
+            className={`${styles.header} ${scrolled ? styles.headerScrolled : ""} ${!scrolled && noScroll ? styles.headerNoScroll : ""}`}
             id="top"
             data-aos="fade-down"
             data-aos-duration="400"
@@ -61,7 +84,7 @@ export default function Header() {
                     <a href="#" className={styles.brand} aria-label="BBQ Chicken home">
                         <img
                             width="85" height="85"
-                            src={`${scrolled ? "/Good-Chicken-logo.png" : "/Good-Chicken-white-logo.png"}`}
+                            src={darkAssets ? "/Good-Chicken-logo.png" : "/Good-Chicken-white-logo.png"}
                             alt="Good Chicken"
                         />
                     </a>
@@ -103,7 +126,7 @@ export default function Header() {
                     </ul>
                     <a href="#" className={`${styles.brand} ${styles.centerBrand}`} aria-label="BBQ Chicken home">
                         <img width="85" height="85"
-                             src={`${scrolled ? "/Good-Chicken-logo.png" : "/Good-Chicken-white-logo.png"}`}
+                             src={darkAssets ? "/Good-Chicken-logo.png" : "/Good-Chicken-white-logo.png"}
                              alt="Good Chicken"/>
                     </a>
 

--- a/src/app/components/Order/Location/ChosenLocation.tsx
+++ b/src/app/components/Order/Location/ChosenLocation.tsx
@@ -91,7 +91,7 @@ export default function ChosenLocation() {
                 </div>
 
                 {/* Address */}
-                <div className="mt-1 text-sm text-neutral-700">828 N State Rt 17, Paramus, NJ 07652</div>
+                <div className="mt-1 text-sm text-neutral-700">414 Grand St Jersey City, NJ 07302</div>
 
                 {/* Description */}
                 <p className="mt-3 max-w-3xl text-sm leading-relaxed text-neutral-800">
@@ -166,7 +166,7 @@ export default function ChosenLocation() {
                     </div>
 
                     {/* Open / hours */}
-                    <div className="border border-[#212427]-t p-4">
+                    <div className="border p-4">
                         <div className="flex items-center gap-2">
                             <span className="inline-flex h-2 w-2 rounded-full bg-green-500" aria-hidden="true"/>
                             <span className="text-sm font-medium">Open</span>

--- a/src/app/components/Order/Menu/Menu.tsx
+++ b/src/app/components/Order/Menu/Menu.tsx
@@ -16,6 +16,7 @@ import Water from "@/app/components/Order/Menu/products/water";
 import Soda from "@/app/components/Order/Menu/products/soda";
 import IcedTea from "@/app/components/Order/Menu/products/icedTea";
 import {CardItem, Category} from "@/app/lib/types";
+import {useCart} from "@/app/lib/cart";
 
 export const CATEGORIES: Category[] = [
     {id: 'all', label: 'ALL', icon: <MenuIcon className="h-4 w-4"/>},
@@ -151,6 +152,7 @@ export default function OrderingMenu() {
     const [open, setOpen] = useState(false);
     const [current, setCurrent] = useState<ConfigProduct | null>(null);
     const [sel, setSel] = useState<Partial<{ heat: string; part: string; size: string }>>({});
+    const {addItem} = useCart();
 
     const filtered = useMemo(() => {
         if (active === 'all') return ITEMS;
@@ -164,10 +166,9 @@ export default function OrderingMenu() {
         setOpen(true);
     }
 
-    // TODO: wire to your cart hook
     function handleAdd({sku, name, priceCents}: { sku: string; name: string; priceCents: number }) {
-        console.log('ADD', {sku, name, priceCents});
-        // addItem(sku, name, priceCents, [])
+        addItem(sku, name, priceCents, []);
+        setOpen(false);
     }
 
     return (

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -119,7 +119,7 @@ a {
 
 
 section {
-    padding: 72px 0;
+    padding: 80px 0;
 }
 
 .section-title {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,4 @@
 import type {Metadata} from "next";
-import {Geist, Geist_Mono} from "next/font/google";
 import "./globals.css";
 import React from "react";
 import Header from "@/app/components/Header/Header";
@@ -37,10 +36,12 @@ export default async function RootLayout({
         <head>
             <script async src="//www.instagram.com/embed.js"></script>
         </head>
-        <body>
-            <Header/>
+        <body className="min-h-screen flex flex-col">
+        <Header/>
+        <main className="flex-1">
             {children}
-            <Footer locations={footerLocations}/>
+        </main>
+        <Footer locations={footerLocations}/>
         </body>
         </html>
     );

--- a/src/app/order/menu/page.tsx
+++ b/src/app/order/menu/page.tsx
@@ -1,0 +1,5 @@
+import MenuScreen from '@/app/screens/MenuScreen';
+
+export default function MenuPage() {
+  return <MenuScreen />;
+}

--- a/src/app/order/page.tsx
+++ b/src/app/order/page.tsx
@@ -1,9 +1,35 @@
 'use client';
 
-import MenuScreen from "@/app/screens/MenuScreen";
+import React from 'react';
+import {useRouter} from 'next/navigation';
 
-export default function OrderRouterPage() {
-    return (
-        <MenuScreen/>
-    );
+const LOCATIONS = [
+  {id: 'montclair', name: 'Montclair'},
+  {id: 'jersey-city', name: 'Jersey City'},
+];
+
+export default function OrderPage() {
+  const router = useRouter();
+
+  function choose(id: string) {
+    try {
+      localStorage.setItem('gc_location', id);
+    } catch {}
+    router.push('/order/menu');
+  }
+
+  return (
+    <main className="mx-auto max-w-md space-y-4 py-10">
+      <h1 className="text-2xl font-bold mb-4 text-center">Choose Location</h1>
+      {LOCATIONS.map(loc => (
+        <button
+          key={loc.id}
+          onClick={() => choose(loc.id)}
+          className="block w-full rounded-lg border px-4 py-3 text-left hover:bg-neutral-50"
+        >
+          {loc.name}
+        </button>
+      ))}
+    </main>
+  );
 }

--- a/src/app/order/page.tsx
+++ b/src/app/order/page.tsx
@@ -4,32 +4,33 @@ import React from 'react';
 import {useRouter} from 'next/navigation';
 
 const LOCATIONS = [
-  {id: 'montclair', name: 'Montclair'},
-  {id: 'jersey-city', name: 'Jersey City'},
+    {id: 'montclair', name: 'Montclair'},
+    {id: 'jersey-city', name: 'Jersey City'},
 ];
 
 export default function OrderPage() {
-  const router = useRouter();
+    const router = useRouter();
 
-  function choose(id: string) {
-    try {
-      localStorage.setItem('gc_location', id);
-    } catch {}
-    router.push('/order/menu');
-  }
+    function choose(id: string) {
+        try {
+            localStorage.setItem('gc_location', id);
+        } catch {
+        }
+        router.push('/order/menu');
+    }
 
-  return (
-    <main className="mx-auto max-w-md space-y-4 py-10">
-      <h1 className="text-2xl font-bold mb-4 text-center">Choose Location</h1>
-      {LOCATIONS.map(loc => (
-        <button
-          key={loc.id}
-          onClick={() => choose(loc.id)}
-          className="block w-full rounded-lg border px-4 py-3 text-left hover:bg-neutral-50"
-        >
-          {loc.name}
-        </button>
-      ))}
-    </main>
-  );
+    return (
+        <section className="mx-auto max-w-md space-y-4 py-10 mt-[var(--header-h)]">
+            <h1 className="text-2xl font-bold mb-4 text-center">Choose Location</h1>
+            {LOCATIONS.map(loc => (
+                <button
+                    key={loc.id}
+                    onClick={() => choose(loc.id)}
+                    className="block w-full rounded-lg border px-4 py-3 text-left hover:bg-neutral-50"
+                >
+                    {loc.name}
+                </button>
+            ))}
+        </section>
+    );
 }

--- a/src/app/screens/MenuScreen.tsx
+++ b/src/app/screens/MenuScreen.tsx
@@ -1,16 +1,16 @@
 'use client';
 
 import React from 'react';
-import OrderingMenu from "@/app/components/Order/Menu/Menu";
-import ChosenLocation from "@/app/components/Order/Location/ChosenLocation";
-
+import OrderingMenu from '@/app/components/Order/Menu/Menu';
+import CartDrawer from '@/app/components/CartDrawer/CartDrawer';
 
 export default function MenuScreen() {
-
-    return (
-        <section className="flex items-center justify-between flex-col gap-2">
-            <ChosenLocation />
-            <OrderingMenu />
-        </section>
-    );
+  return (
+    <main className="mx-auto max-w-6xl px-4 py-6 mt-6 grid grid-cols-1 gap-6 lg:grid-cols-3">
+      <div className="lg:col-span-2">
+        <OrderingMenu />
+      </div>
+      <CartDrawer />
+    </main>
+  );
 }

--- a/src/app/screens/MenuScreen.tsx
+++ b/src/app/screens/MenuScreen.tsx
@@ -3,14 +3,16 @@
 import React from 'react';
 import OrderingMenu from '@/app/components/Order/Menu/Menu';
 import CartDrawer from '@/app/components/CartDrawer/CartDrawer';
+import ChosenLocation from "@/app/components/Order/Location/ChosenLocation";
 
 export default function MenuScreen() {
-  return (
-    <main className="mx-auto max-w-6xl px-4 py-6 mt-6 grid grid-cols-1 gap-6 lg:grid-cols-3">
-      <div className="lg:col-span-2">
-        <OrderingMenu />
-      </div>
-      <CartDrawer />
-    </main>
-  );
+    return (
+        <section className="flex items-center justify-between flex-col gap-2">
+            <ChosenLocation/>
+            <div className="lg:col-span-2">
+            <OrderingMenu/>
+            </div>
+            <CartDrawer/>
+        </section>
+    );
 }


### PR DESCRIPTION
## Summary
- Add location selection page for ordering flow
- Show menu with cart drawer and wire menu items to cart
- Introduce basic checkout page to review cart and place order

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*


------
https://chatgpt.com/codex/tasks/task_e_68bad770ee54833382858a5999f278e1