### PR TITLE
Integrate Supabase order and preference history

### DIFF
--- a/src/app/api/pay/route.ts
+++ b/src/app/api/pay/route.ts
@@ -1,4 +1,5 @@
 import {NextRequest, NextResponse} from 'next/server';
+import {saveOrder} from '@/app/lib/supabase';
 // import { z } from 'zod';
 // import { captureWithOpaque } from '@/lib/authnet';
 // import { addLineItems, createOrder, ensureTenderId, printToKitchen, recordExternalPayment } from '@/lib/clover';
@@ -22,8 +23,20 @@ export const dynamic = 'force-dynamic';
 //
 export async function POST(req: NextRequest) {
     const body = await req.json();
-    // ...your logic...
-    return NextResponse.json({ ok: true });
+    try {
+        const inserted = await saveOrder({
+            items: body.items,
+            subtotal_cents: body.subtotalCents,
+            tax_cents: body.taxCents,
+            tip_cents: body.tipCents,
+            service_fee_cents: body.serviceFeeCents,
+            order_type: body.orderType,
+            customer: body.customer,
+        });
+        return NextResponse.json({ ok: true, orderId: inserted?.[0]?.id });
+    } catch (e: any) {
+        return NextResponse.json({ ok: false, error: e.message }, { status: 500 });
+    }
 }
 
 // export async function POST(req: NextRequest) {

--- a/src/app/api/preferences/route.ts
+++ b/src/app/api/preferences/route.ts
@@ -1,0 +1,19 @@
+import {NextRequest, NextResponse} from 'next/server';
+import {savePreference} from '@/app/lib/supabase';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function POST(req: NextRequest) {
+  const body = await req.json();
+  try {
+    await savePreference({
+      user_id: body.userId,
+      key: body.key,
+      value: body.value,
+    });
+    return NextResponse.json({ ok: true });
+  } catch (e: any) {
+    return NextResponse.json({ ok: false, error: e.message }, { status: 500 });
+  }
+}

--- a/src/app/lib/supabase.ts
+++ b/src/app/lib/supabase.ts
@@ -1,0 +1,28 @@
+const SUPABASE_URL = 'https://ipihtrvjlpyhueazwnph.supabase.co';
+
+async function supabaseFetch(path: string, body: any) {
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY || '';
+  const res = await fetch(`${SUPABASE_URL}${path}`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      apikey: key,
+      Authorization: `Bearer ${key}`,
+      Prefer: 'return=representation',
+    },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    const msg = await res.text();
+    throw new Error(msg || `Supabase error ${res.status}`);
+  }
+  return res.json();
+}
+
+export function saveOrder(order: any) {
+  return supabaseFetch('/rest/v1/orders', order);
+}
+
+export function savePreference(pref: any) {
+  return supabaseFetch('/rest/v1/preferences', pref);
+}

--- a/src/app/order/page.tsx
+++ b/src/app/order/page.tsx
@@ -11,9 +11,19 @@ const LOCATIONS = [
 export default function OrderPage() {
     const router = useRouter();
 
-    function choose(id: string) {
+    async function choose(id: string) {
         try {
             localStorage.setItem('gc_location', id);
+            let userId = localStorage.getItem('gc_user_id');
+            if (!userId) {
+                userId = crypto.randomUUID();
+                localStorage.setItem('gc_user_id', userId);
+            }
+            await fetch('/api/preferences', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ userId, key: 'location', value: id }),
+            });
         } catch {
         }
         router.push('/order/menu');


### PR DESCRIPTION
## Summary
- add Supabase REST helpers
- save orders to Supabase from `/api/pay`
- record user preferences via new `/api/preferences`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_68bb1178bdf483339924d6c56fbdb3dc